### PR TITLE
murdock-slave-init: add cpu-set handling for docker

### DIFF
--- a/murdock-slave-init.sh
+++ b/murdock-slave-init.sh
@@ -45,6 +45,8 @@ _start() {
         -e CCACHE="ccache" \
         -e CCACHE_MAXSIZE \
         -e DWQ_SSH \
+        ${MURDOCK_CPUSET_CPUS:+--cpuset-cpus=${MURDOCK_CPUSET_CPUS}} \
+        ${MURDOCK_CPUSET_MEMS:+--cpuset-mems=${MURDOCK_CPUSET_MEMS}} \
         --security-opt seccomp=unconfined \
         --name ${MURDOCK_INSTANCE} \
         ${MURDOCK_CONTAINER} \


### PR DESCRIPTION
Allows to set cpuset and numa ids for the underlying docker instance. Environment variables can be passed via the existing systemd service file.